### PR TITLE
Add example query for induction periods en masse

### DIFF
--- a/build/setup.sql
+++ b/build/setup.sql
@@ -141,7 +141,10 @@ insert into mentorships(id, mentor_id, mentee_id, started_on, finished_on) value
   (10, 20, 10, '2021-10-05', '2022-03-09'),
   (11, null, 11, '2021-10-05', null),
   (12, 23, 12, '2021-10-05', null),
-  (13, 22, 13, '2021-10-05', null)
+  (13, 22, 13, '2021-10-05', null),
+
+  (14, 21, 10, '2022-08-10', '2023-01-05'),
+  (15, 21, 6, '2022-05-04', '2023-03-09')
 ;
 
 create table appropriate_body_associations (

--- a/example-queries/total-induction-time.sql
+++ b/example-queries/total-induction-time.sql
@@ -1,0 +1,72 @@
+with
+  -- convert each started_on to finished_on span to
+  -- a daterange. We want to cap ongoing ranges with
+  -- the current_date so we're not looking into the future
+  -- unnecessarily
+  mentorship_ranges as (
+    select
+      mentee_id as participant_id,
+      daterange(
+        m.started_on,
+        coalesce(m.finished_on, current_date)
+      ) range
+    from
+      mentorships m
+    ),
+
+  -- combine the individual ranges into a multirange
+  mentorship_multiranges as (
+    select
+      participant_id,
+      range_agg(range) as multiranges
+    from
+      mentorship_ranges
+    group by
+      participant_id
+  ),
+
+  -- now repeat the two steps above for appropriate body
+  -- associations
+  appropriate_body_association_ranges as (
+    select
+      participant_id,
+      daterange(
+        aba.started_on,
+        coalesce(aba.finished_on, current_date)
+      ) range
+    from
+      appropriate_body_associations aba
+  ),
+  appropriate_body_association_multiranges as (
+    select
+      participant_id,
+      range_agg(range) as multiranges
+    from
+      appropriate_body_association_ranges
+    group by
+      participant_id
+  ),
+
+  -- work out the intersections between the mentorship
+  -- and appropriate body multiranges and unnest them
+  -- to separate rows
+  unnested_overlaps as (
+    select
+      mm.participant_id,
+      unnest(mm.multiranges * abam.multiranges) as overlap
+    from
+      mentorship_multiranges mm
+    inner join
+      appropriate_body_association_multiranges abam
+        on mm.participant_id = abam.participant_id
+  )
+
+-- finally convert the mentorship/ab overlaps into durations
+-- and sum them for a total
+select
+  participant_id,
+  sum(upper(overlap) - lower(overlap)) total_days
+from
+  unnested_overlaps
+group by
+  participant_id;


### PR DESCRIPTION
Induction is active when a participant has both:

* an ongoing mentorship
* an assigned appropriate body

To look back and calculate how much time someone spent being inducted is really easy for a single participant in Ruby, we can build a Set of all the days mentorships were ongoing, do the same for AB appointments, and then intersect them:

```ruby
mentorship_days & ab_days
```

Doing this for all participants at once will be slower and memory heavy in the app, but we can do it _really quickly_ in the database by using PostgreSQL's ranges to our advantage. This example query demonstrats how we can work out the total induction time for all participants by:

1. converting each record's start and finish date to a daterange
2. combining each participants dateranges into a multidaterange
3. intersecting the multidateranges with *
4. unnesting the overlaps and converting them to durations
5. summing the durations
